### PR TITLE
Use jdk1.7 for compilation

### DIFF
--- a/all/build.xml
+++ b/all/build.xml
@@ -209,10 +209,10 @@
 			</condition>
 		</fail>
 
-		<fail message="Java Runtime version 1.6 needed. Your version is: ${java.runtime.version}">
+		<fail message="Java Runtime version 1.7 needed. Your version is: ${java.runtime.version}">
 			<condition>
 				<not>
-					<contains string="${java.runtime.version}" substring="1.6" casesensitive="false"/>
+					<contains string="${java.runtime.version}" substring="1.7" casesensitive="false"/>
 				</not>
 			</condition>
 		</fail>


### PR DESCRIPTION
As JDK 1.6 is deprecated for some times now, JNode should be able to compile with at least JDK 1.7.
